### PR TITLE
feat(KK-10943): Add user agent header to request header

### DIFF
--- a/lib/helpers/dispatch.js
+++ b/lib/helpers/dispatch.js
@@ -15,6 +15,7 @@ function sendRequest(reqBody, url, accessToken) {
 		headers: {
 			'Accept': 'application/json',
 			'Content-Type': 'application/json',
+            'User-Agent': 'Kopokopo-Node-SDK',
 			'Authorization': `Bearer ${accessToken}`
 		}
 	})
@@ -49,6 +50,7 @@ function getContent(url, accessToken) {
 		headers: {
 		'Accept': 'application/json',
 		'Content-Type': 'application/json',
+        'User-Agent': 'Kopokopo-Node-SDK',
 		'Authorization': `Bearer ${accessToken}`
 		}
 	})

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -35,7 +35,8 @@ function TokenService(options) {
 		return axios.post(`${baseUrl}/oauth/token`, requestBody, {
 			headers: {
 				'Accept': 'application/json',
-				'Content-Type': 'application/x-www-form-urlencoded'
+				'Content-Type': 'application/x-www-form-urlencoded',
+                'User-Agent': 'Kopokopo-Node-SDK'
 			}
 		})
 		.then(response => response.data)


### PR DESCRIPTION
This pull request makes a small update to the HTTP request headers in the `sendRequest` function to give visibility into K2 Connect usage.

* Added a custom `User-Agent` header (`Kopokopo-Node-SDK`) to all outgoing requests in `lib/helpers/dispatch.js`.