### PR TITLE
FIX(KK-12221): Fix example app payment link response throwing error: …

### DIFF
--- a/example/routes/payment_links.js
+++ b/example/routes/payment_links.js
@@ -74,7 +74,7 @@ router.post("/cancel", async function (req, res, next) {
         
         res.render("payment_links", {
             action: 'cancel',
-            message: `Response: ${JSON.stringify(response)}`,
+            message: `Response: ${JSON.stringify(response.data)}`,
             ...res.locals.commonData
         });
     } catch (error) {


### PR DESCRIPTION
ix example app payment link response throwing error 

node : Converting circular structure to JSON
    --> starting at object with constructor 'ClientRequest'
    |     property 'res' -> object with constructor 'IncomingMessage'
    --- property 'req' closes the circle*
